### PR TITLE
UMD pattern for CommonJS and AMD compatibility

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,7 @@ module.exports = function(grunt) {
     concat: {
       dist: {
         src: [
+          'src/prologue.js',
           'src/Util.js', 
           'src/MoveableMarker.js',
           'src/Track.js',
@@ -12,7 +13,8 @@ module.exports = function(grunt) {
           'src/Clock.js',
           'src/TracksLayer.js',
           'src/Control.js',
-          'src/Playback.js'
+          'src/Playback.js',
+          'src/epilogue.js'
         ],
         dest: 'dist/LeafletPlayback.js'
       }

--- a/src/epilogue.js
+++ b/src/epilogue.js
@@ -1,0 +1,3 @@
+return L.Playback;
+
+}));

--- a/src/prologue.js
+++ b/src/prologue.js
@@ -1,0 +1,17 @@
+// UMD initialization to work with CommonJS, AMD and basic browser script include
+(function (factory) {
+	var L;
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['leaflet'], factory);
+	} else if (typeof module === 'object' && typeof module.exports === "object") {
+		// Node/CommonJS
+		L = require('leaflet');
+		module.exports = factory(L);
+	} else {
+		// Browser globals
+		if (typeof window.L === 'undefined')
+			throw 'Leaflet must be loaded first';
+		factory(window.L);
+	}
+}(function (L) {


### PR DESCRIPTION
This makes it easy to use the plugin when using Browserify/CommonJS and RequireJS/AMD, while still remaining compatible with normal script includes.