### PR TITLE
Add options dateFormatFn and timeFormatFn

### DIFF
--- a/src/Control.js
+++ b/src/Control.js
@@ -2,10 +2,13 @@ L.Playback = L.Playback || {};
 
 L.Playback.DateControl = L.Control.extend({
     options : {
-        position : 'bottomleft'
+        position : 'bottomleft',
+        dateFormatFn: L.Playback.Util.DateStr,
+        timeFormatFn: L.Playback.Util.TimeStr
     },
 
-    initialize : function (playback) {
+    initialize : function (playback, options) {
+        L.setOptions(this, options);
         this.playback = playback;
     },
 
@@ -22,13 +25,13 @@ L.Playback.DateControl = L.Control.extend({
         this._date = L.DomUtil.create('p', '', datetime);
         this._time = L.DomUtil.create('p', '', datetime);
 
-        this._date.innerHTML = L.Playback.Util.DateStr(time);
-        this._time.innerHTML = L.Playback.Util.TimeStr(time);
+        this._date.innerHTML = this.options.dateFormatFn(time);
+        this._time.innerHTML = this.options.timeFormatFn(time);
 
         // setup callback
         playback.addCallback(function (ms) {
-            self._date.innerHTML = L.Playback.Util.DateStr(ms);
-            self._time.innerHTML = L.Playback.Util.TimeStr(ms);
+            self._date.innerHTML = self.options.dateFormatFn(ms);
+            self._time.innerHTML = self.options.timeFormatFn(ms);
         });
 
         return this._container;

--- a/src/Playback.js
+++ b/src/Playback.js
@@ -59,7 +59,7 @@ L.Playback = L.Playback.Clock.extend({
             }
 
             if (this.options.dateControl) {
-                this.dateControl = new L.Playback.DateControl(this);
+                this.dateControl = new L.Playback.DateControl(this, options);
                 this.dateControl.addTo(map);
             }
 


### PR DESCRIPTION
This allows overriding the default date and time formatting functions, which is important for internationalization. Makes it easy to use for example Moment.js.