### PR TITLE
Add destroy method

### DIFF
--- a/src/Playback.js
+++ b/src/Playback.js
@@ -101,6 +101,19 @@ L.Playback = L.Playback.Clock.extend({
             if (this.options.tracksLayer) {
                 this._tracksLayer.addLayer(geoJSON);
             }                  
+        },
+
+        destroy: function() {
+            this.clearData();
+            if (this.playControl) {
+                this._map.removeControl(this.playControl);
+            }
+            if (this.sliderControl) {
+                this._map.removeControl(this.sliderControl);
+            }
+            if (this.dateControl) {
+                this._map.removeControl(this.dateControl);
+            }
         }
     });
 


### PR DESCRIPTION
This adds a method that removes any data and controls from the map, effectively destroying the instance.

This is needed in my app since playback is a special mode in the application, and the user has to be able to exit the playback mode.