### PR TITLE
Add hideInactive option

### DIFF
--- a/src/Playback.js
+++ b/src/Playback.js
@@ -17,6 +17,7 @@ L.Playback = L.Playback.Clock.extend({
             tickLen: 250,
             speed: 1,
             maxInterpolationTime: 5*60*1000, // 5 minutes
+            hideInactive: false,
 
             tracksLayer : true,
             

--- a/src/Track.js
+++ b/src/Track.js
@@ -5,11 +5,12 @@ L.Playback.Track = L.Class.extend({
         initialize : function (geoJSON, options) {
             options = options || {};
             var tickLen = options.tickLen || 250;
-            
+
             this._geoJSON = geoJSON;
             this._tickLen = tickLen;
             this._ticks = [];
             this._marker = null;
+            this._hideInactive = options.hideInactive
 
             var sampleTimes = geoJSON.properties.time;
             var samples = geoJSON.geometry.coordinates;
@@ -141,10 +142,24 @@ L.Playback.Track = L.Class.extend({
         },
         
         tick : function (timestamp) {
-            if (timestamp > this._endTime)
+            if (this._hideInactive) {
+                if (timestamp > this._endTime || timestamp < this._startTime) {
+                    if (this._marker._map) {
+                        this._marker._mmap.removeLayer(this._marker);
+                    }
+                }
+                else if (!this._marker._map) {
+                    this._marker._mmap.addLayer(this._marker)
+                }
+            }
+
+            if (timestamp > this._endTime) {
                 timestamp = this._endTime;
-            if (timestamp < this._startTime)
+            }
+            else if (timestamp < this._startTime) {
                 timestamp = this._startTime;
+            }
+
             return this._ticks[timestamp];
         },
         

--- a/src/TrackController.js
+++ b/src/TrackController.js
@@ -57,9 +57,10 @@ L.Playback.TrackController = L.Class.extend({
 
         if (marker) {
             marker.addTo(this._map);
+            marker._mmap = this._map
             
             this._tracks.push(track);
-        }            
+        }
     },
 
     tock : function (timestamp, transitionTime) {


### PR DESCRIPTION
I have added an option `hideInactive` to hide markers if the current time is before their first time property or after their very last one. I didn't know of a best practice to simply hide an existing marker in Leaflet. Instead of `setOpacity(0)` I removed the marker from the map and added it on reactivation.

Split the functionality to an `isActive()` property might also be a good idea to later update only positions of tracks whose time range is currently hit.