### PR TITLE
Force transform-origin to marker center

### DIFF
--- a/src/MoveableMarker.js
+++ b/src/MoveableMarker.js
@@ -76,6 +76,7 @@ L.Playback.MoveableMarker = L.Marker.extend({
         transform += ' translate(' + -a.x + 'px, ' + -a.y + 'px)';
         transform += ' rotate(' + this.options.iconAngle + 'deg)';
         transform += ' translate(' + a.x + 'px, ' + a.y + 'px)';
+        i.style.transformOrigin = '50% 50% 0';
         i.style[L.DomUtil.TRANSFORM] += transform;
     },
     setIconAngle: function (iconAngle) {


### PR DESCRIPTION
LeafLet 1.0.1 overrides the transform-origin for markers and that causes an offset when markers are oriented. This forces the origin to the default (center) before applying the CSS transformation